### PR TITLE
[RA-918] Home-screen is empty for users _ Fixed

### DIFF
--- a/api/src/main/java/org/openmrs/module/adminui/AdminUiConstants.java
+++ b/api/src/main/java/org/openmrs/module/adminui/AdminUiConstants.java
@@ -15,7 +15,7 @@ public class AdminUiConstants {
 	
 	//from EmrApi module
 	
-	public static final String ROLE_PREFIX_CAPABILITY = "Application Role: ";
+	public static final String ROLE_PREFIX_CAPABILITY = "Application: ";
 	
 	public static final String ROLE_PREFIX_PRIVILEGE_LEVEL = "Privilege Level: ";
 	


### PR DESCRIPTION
<img width="972" alt="screen shot 2016-02-05 at 7 53 19 pm" src="https://cloud.githubusercontent.com/assets/829714/12863954/6b08562a-cc44-11e5-9b50-40b06aa992dd.png">
