### PR TITLE
Added logic to apply language changes instanly without forcing user to perform re-login

### DIFF
--- a/omod/src/main/java/org/openmrs/module/adminui/page/controller/myaccount/ChangeDefaultsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/adminui/page/controller/myaccount/ChangeDefaultsPageController.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.adminui.page.controller.myaccount;
 
+import java.util.Locale;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -23,9 +24,11 @@ import org.openmrs.ui.framework.annotation.BindParams;
 import org.openmrs.ui.framework.annotation.MethodParam;
 import org.openmrs.ui.framework.annotation.SpringBean;
 import org.openmrs.ui.framework.page.PageModel;
+import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.i18n.CookieLocaleResolver;
 
 public class ChangeDefaultsPageController {
 
@@ -52,6 +55,14 @@ public class ChangeDefaultsPageController {
             props.put(OpenmrsConstants.USER_PROPERTY_PROFICIENT_LOCALES, userDefaults.getProficientLocales());
             user.setUserProperties(props);
             userService.saveUser(user, null);
+
+            // set the locale based on the locale selected by user
+            Locale newLocale = normalizeLocale(userDefaults.getDefaultLocale());
+            if (newLocale != null) {
+                Context.getUserContext().setLocale(newLocale);
+                new CookieLocaleResolver().setDefaultLocale(newLocale);
+            }
+
             InfoErrorMessageUtil.flashInfoMessage(request.getSession(), "adminui.account.defaults.success");
         } catch (Exception ex) {
             request.getSession().setAttribute(
@@ -66,6 +77,35 @@ public class ChangeDefaultsPageController {
     		@RequestParam(value = "proficientLocales", required = false) String proficientLocales) {
     	
     	return new UserDefaults(defaultLocale, proficientLocales);
+    }
+
+    public static Locale normalizeLocale(String localeString) {
+        if (localeString == null) {
+            return null;
+        } else {
+            localeString = localeString.trim();
+            if (localeString.isEmpty()) {
+                return null;
+            } else {
+                int len = localeString.length();
+
+                for (int locale = 0; locale < len; ++locale) {
+                    char c = localeString.charAt(locale);
+                    if ((c <= 32 || c >= 127 || (c >= 32 || c <= 127) && !Character.isLetter(c) && c != 95) && c != 9) {
+                        localeString = localeString.replaceFirst(Character.valueOf(c).toString(), "");
+                        --len;
+                        --locale;
+                    }
+                }
+
+                Locale var4 = LocaleUtility.fromSpecification(localeString);
+                if (LocaleUtility.isValid(var4)) {
+                    return var4;
+                } else {
+                    return null;
+                }
+            }
+        }
     }
 
     public class UserDefaults {
@@ -97,4 +137,5 @@ public class ChangeDefaultsPageController {
             this.proficientLocales = proficientLocales;
         }
     }
+
 }


### PR DESCRIPTION
The commit fixes one of the points discussed in: https://issues.openmrs.org/browse/RA-995

I've added a logic in ChangeDefaultsPageController to apply the language changes made by user to the ongoing session thus preventing the user to perform a re-login in order to see the language changes in effect.