### PR TITLE
RA-807 Added ManageVisitType to Metadata management

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -258,6 +258,12 @@ adminui.visits.title=Visits
 adminui.manageVisitAttributeTypes.title=Manage Visit Attribute Types
 adminui.addNewVisitAttributeType.title=Add New Visit Attribute Type
 adminui.editVisitAttributeType.title=Edit Visit Attribute Type
+adminui.manageVisitTypes.title=Manage Visit Types
+adminui.addNewVisitType.title=Add New Visit Type
+adminui.editVisitType.title=Edit Visit Type
+adminui.visitType.retire.title=Retire Visit Type
+adminui.visitType.purge.title=Delete Visit Type
+adminui.visitType.purge.success=Visit Type Deleted
 
 adminui.app.configureMetadata.label=Configure Metadata
 adminui.configuremetadata.adminGroups.description=Extension point for the groupings on the Configure Metadata page

--- a/omod/src/main/resources/apps/adminui_configuremetadata_admin_links_extension.json
+++ b/omod/src/main/resources/apps/adminui_configuremetadata_admin_links_extension.json
@@ -48,6 +48,18 @@
     },
 
     {
+        "id": "${project.parent.groupId}.${project.parent.artifactId}.visits",
+        "extensionPointId": "${project.parent.groupId}.${project.parent.artifactId}.adminLinks",
+        "type": "link",
+        "label": "${project.parent.artifactId}.manageVisitTypes.title",
+        "url": "${project.parent.artifactId}/metadata/visits/visittypes/manageVisitTypes.page",
+        "requiredPrivilege": "Manage Visit Types",
+        "extensionParams":{
+            "group": "${project.parent.groupId}.${project.parent.artifactId}.visits.group"
+        }
+    },
+
+    {
         "id": "${project.parent.groupId}.${project.parent.artifactId}.encounters",
         "extensionPointId": "${project.parent.groupId}.${project.parent.artifactId}.adminLinks",
         "type": "link",

--- a/omod/src/main/webapp/pages/metadata/visits/visittypes/manageVisitTypes.gsp
+++ b/omod/src/main/webapp/pages/metadata/visits/visittypes/manageVisitTypes.gsp
@@ -1,0 +1,47 @@
+<%
+    ui.decorateWith("appui", "standardEmrPage")
+
+    ui.includeJavascript("uicommons", "angular.min.js")
+    ui.includeJavascript("uicommons", "angular-resource.min.js")
+    ui.includeJavascript("uicommons", "angular-ui/angular-ui-router.min.js")
+    ui.includeJavascript("uicommons", "angular-app.js")
+    ui.includeJavascript("uicommons", "angular-common.js")
+    ui.includeJavascript("uicommons", "angular-common-error.js")
+    ui.includeJavascript("uicommons", "services/visitTypeService.js")
+    ui.includeJavascript("uicommons", "filters/display.js")
+    ui.includeJavascript("uicommons", "filters/serverDate.js")
+
+    ui.includeJavascript("uicommons", "ngDialog/ngDialog.js")
+    ui.includeCss("uicommons", "ngDialog/ngDialog.min.css")
+    ui.includeCss("adminui", "adminui.css")
+
+    ui.includeJavascript("adminui", "metadata/manageVisitTypes.js")
+%>
+
+<script type="text/javascript">
+    var breadcrumbs = [
+        { icon: "icon-home", link: '/' + OPENMRS_CONTEXT_PATH + '/index.htm' },
+        { label: "${ ui.message('adminui.app.configureMetadata.label')}", link: '${ui.pageLink("adminui", "metadata/configureMetadata")}'},
+        { label: "${ ui.message("adminui.manageVisitTypes.title")}" }
+    ];
+    emr.loadMessages([
+        "adminui.saved",
+        "adminui.savedChanges",
+        "adminui.retired",
+        "adminui.restored",
+        "adminui.purged",
+        "adminui.save.fail",
+        "adminui.saveChanges.fail",
+        "adminui.retire.fail",
+        "adminui.restore.fail",
+        "adminui.purge.fail"
+    ]);
+</script>
+
+<div id="manage-visit-types">
+    <ui-view/>
+</div>
+
+<script type="text/javascript">
+    angular.bootstrap("#manage-visit-types", [ "manageVisitTypes" ])
+</script>

--- a/omod/src/main/webapp/pages/metadata/visits/visittypes/templates/edit.gsp
+++ b/omod/src/main/webapp/pages/metadata/visits/visittypes/templates/edit.gsp
@@ -1,0 +1,39 @@
+<h2 ng-hide="visitType.uuid">${ui.message('adminui.addNewVisitType.title')}</h2>
+<h2 ng-show="visitType.uuid">${ui.message('adminui.editVisitType.title')}</h2>
+
+<fieldset class="right" ng-show="visitType.uuid">
+    <legend>${ui.message('general.auditInfo')}</legend>
+    <p>
+        ${ui.message('general.uuid')}: {{ visitType.uuid }}
+    </p>
+    <p>
+        ${ui.message('general.createdBy')}:
+        {{ visitType.auditInfo.creator | omrsDisplay }}
+        ${ui.message('general.onDate')}
+        {{ visitType.auditInfo.dateCreated | serverDate }}
+    </p>
+    <p ng-show="visitType.changedBy">
+        ${ui.message('general.changedBy')}:
+        {{ visitType.auditInfo.changedBy | omrsDisplay }}
+        ${ui.message('general.onDate')}
+        {{ visitType.auditInfo.dateChanged | serverDate }}
+    </p>
+</fieldset>
+
+
+<form class="simple-form-ui" name="visitTypeForm" novalidate ng-submit="save()">
+    <p>
+        <label>${ui.message('general.name')}</label>
+        <input ng-model="visitType.name" required/>
+    </p>
+    <p>
+        <label>${ui.message('general.description')}</label>
+        <textarea ng-model="visitType.description" cols="54" required></textarea>
+    </p>
+
+    <p>
+        <button ng-disabled="visitTypeForm.\$invalid" type="submit" class="confirm right">${ui.message('general.save')}</button>
+        <button type="button" class="cancel" ui-sref="list">${ui.message('general.cancel')}</button>
+    </p>
+</form>
+

--- a/omod/src/main/webapp/pages/metadata/visits/visittypes/templates/list.gsp
+++ b/omod/src/main/webapp/pages/metadata/visits/visittypes/templates/list.gsp
@@ -1,0 +1,33 @@
+<button ui-sref="edit">${ ui.message("adminui.addNewVisitType.title") }</button>
+<br/>
+<br/>
+
+<table>
+    <thead>
+    <tr>
+        <th class="adminui-name-column">${ui.message('general.name')}</th>
+        <th>${ui.message('general.description')}</th>
+        <th class="adminui-action-column">${ui.message('general.action')}</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr ng-repeat="visitType in visitTypes">
+        <td valign="top" ng-class="{ retired: visitType.retired }">{{visitType.name}}</td>
+        <td valign="top" ng-class="{ retired: visitType.retired }">{{visitType.description}}</td>
+        <td valign="top">
+            <a ng-hide="visitType.retired" ui-sref="edit({visitTypeUuid: visitType.uuid})">
+                <i class="icon-pencil edit-action" title="${ui.message("emr.edit")}"></i>
+            </a>
+            <a ng-hide="visitType.retired" ng-click="retire(visitType)">
+                <i class="icon-remove delete-action" title="${ui.message("emr.delete")}"></i>
+            </a>
+            <a ng-show="visitType.retired" ng-click="unretire(visitType)">
+                <i class="icon-reply edit-action" title="${ui.message("general.restore")}"></i>
+            </a>
+            <a ng-click="purge(visitType)" class="right">
+                <i class="icon-trash delete-action" title="${ui.message("general.purge")}"></i>
+            </a>
+        </td>
+    </tr>
+    </tbody>
+</table>

--- a/omod/src/main/webapp/pages/metadata/visits/visittypes/templates/purgeVisitTypeDialog.gsp
+++ b/omod/src/main/webapp/pages/metadata/visits/visittypes/templates/purgeVisitTypeDialog.gsp
@@ -1,0 +1,13 @@
+<div class="dialog-header">
+    <h3>${ui.message('adminui.visitType.purge.title')}</h3>
+</div>
+<div class="dialog-content">
+    <h4>
+        {{ '${ui.message("adminui.purge")}'.replace('{0}', visitType.name) }}
+    </h4>
+    <br />
+    <div>
+        <button class="confirm right" ng-click="confirm(reason)">${ ui.message("uicommons.confirm") }</button>
+        <button class="cancel" ng-click="closeThisDialog()">${ ui.message("uicommons.cancel") }</button>
+    </div>
+</div>

--- a/omod/src/main/webapp/pages/metadata/visits/visittypes/templates/retireVisitTypeDialog.gsp
+++ b/omod/src/main/webapp/pages/metadata/visits/visittypes/templates/retireVisitTypeDialog.gsp
@@ -1,0 +1,16 @@
+<div class="dialog-header">
+    <h3>${ui.message("adminui.visitType.retire.title")}</h3>
+</div>
+<div class="dialog-content">
+    <h4>
+        {{ '${ui.message("adminui.retire")}'.replace('{0}', visitType.name) }}
+    </h4>
+    <p>
+        ${ui.message("general.reason")}: <input type="text" ng-model="reason" placeholder="${ ui.message("emr.optional") }"/>
+    </p>
+    <br/>
+    <div>
+        <button class="confirm right" ng-click="confirm(reason)">${ ui.message("uicommons.confirm") }</button>
+        <button class="cancel" ng-click="closeThisDialog()">${ ui.message("uicommons.cancel") }</button>
+    </div>
+</div>

--- a/omod/src/main/webapp/resources/scripts/metadata/manageVisitTypes.js
+++ b/omod/src/main/webapp/resources/scripts/metadata/manageVisitTypes.js
@@ -1,0 +1,116 @@
+angular.module("manageVisitTypes", [ "visitTypeService", "ngDialog", "ui.router", "uicommons.filters", "uicommons.common.error"])
+
+    .config([ "$stateProvider", "$urlRouterProvider", function($stateProvider, $urlRouterProvider) {
+        $urlRouterProvider.otherwise("/list");
+
+        $stateProvider
+            .state('list', {
+                url: "/list",
+                templateUrl: "templates/list.page",
+                controller: "ManageVisitTypesController"
+            })
+            .state("edit", {
+                url: "/edit/:visitTypeUuid",
+                templateUrl: "templates/edit.page",
+                params: {
+                    visitTypeUuid: null,
+                },
+                resolve: {
+                    visitType: function($stateParams, VisitType) {
+                        if ($stateParams.visitTypeUuid) {
+                            return VisitType.get({ uuid: $stateParams.visitTypeUuid, v: "full" });
+                        }
+                        return {};
+                    }
+                },
+                controller: "EditVisitTypeController"
+            });
+    }])
+
+    .controller("ManageVisitTypesController", [ "$scope", "$state", "VisitType", "VisitTypeService", "ngDialog",
+        function($scope, $state, VisitType, VisitTypeService, ngDialog) {
+            function sortWithRetiredLast(list) {
+                return _.sortBy(list, "retired");
+            }
+
+            function loadVisitTypes() {
+                VisitTypeService.getVisitTypes({ v: "default", includeAll: true }).then(function(results) {
+                    $scope.visitTypes = sortWithRetiredLast(results);
+                });
+            }
+
+            $scope.retire = function(visitType) {
+                ngDialog.openConfirm({
+                    showClose: false,
+                    closeByEscape: true,
+                    closeByDocument: true,
+                    template: "templates/retireVisitTypeDialog.page",
+                    controller: function($scope) {
+                        $scope.visitType = visitType;
+                    }
+                }).then(function(reason) {
+                    VisitType.delete({
+                        uuid: visitType.uuid,
+                        reason: reason
+                    }).$promise.then(function() {
+                        loadVisitTypes();
+                        emr.successMessage(emr.message("adminui.retired"));
+                    });
+                });
+            }
+
+            $scope.unretire = function(visitType) {
+                VisitType.save({
+                    uuid: visitType.uuid,
+                    retired: false
+                }).$promise.then(function() {
+                    loadVisitTypes();
+                    emr.successMessage(emr.message("adminui.restored"));
+                })
+            }
+
+            $scope.edit = function(visitType) {
+                $state.go("edit", { visitvisitTypeUuid: visitType.uuid });
+            },
+
+                $scope.purge = function(visitType) {
+                    ngDialog.openConfirm({
+                        showClose: false,
+                        closeByEscape: true,
+                        closeByDocument: true,
+                        template: "templates/purgeVisitTypeDialog.page",
+                        controller: function($scope) {
+                            $scope.visitType = visitType;
+                        }
+                    }).then(function() {
+                        VisitType.delete({
+                            uuid: visitType.uuid,
+                            purge: ""
+                        }).$promise.then(function() {
+                            loadVisitTypes();
+                            emr.successMessage(emr.message("adminui.purged"));
+                        })
+                    });
+                }
+
+            loadVisitTypes();
+        }])
+
+    .controller("EditVisitTypeController", [ "$scope", "$state", "VisitType", "visitType",
+        function($scope, $state, VisitType, visitType) {
+            $scope.visitType = visitType;
+
+            $scope.save = function() {
+                var toSave = {
+                    uuid: $scope.visitType.uuid,
+                    name: $scope.visitType.name,
+                    description: $scope.visitType.description
+                }
+
+                var successMessageCode = ($scope.visitType.uuid) ? "adminui.savedChanges" : "adminui.saved";
+                VisitType.save(toSave).$promise.then(function() {
+                    $state.go("list");
+                    emr.successMessage(emr.message(successMessageCode));
+                })
+            }
+        }]);


### PR DESCRIPTION
# Summary # 

Added Manage Visit Types to Configure Metadata Page. Now users can add, update, delete, retire and unretire visit types from the Configure Metadata Page in adminUI.

## JIRA Ticket ##

Ticket : https://issues.openmrs.org/browse/RA-807

## Screenshots ##
Configure Metadata Page
![image](https://user-images.githubusercontent.com/17599049/38681516-8253d92e-3e86-11e8-9496-ab0059bcd888.png)

Visit Types listing page
![image](https://user-images.githubusercontent.com/17599049/38681523-8748b1ac-3e86-11e8-9412-d1bd253dbc93.png)

Add/Edit Visit Type Page
![image](https://user-images.githubusercontent.com/17599049/38681530-8ba951ac-3e86-11e8-8055-802492253fd3.png)
