### PR TITLE
RA-1513 Added support to allow the extensions to add the custom fragments to the Manage Account dashboard

### DIFF
--- a/api/src/main/java/org/openmrs/module/adminui/account/Account.java
+++ b/api/src/main/java/org/openmrs/module/adminui/account/Account.java
@@ -31,6 +31,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.adminui.AdminUiConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.web.user.UserProperties;
+import org.openmrs.PersonAttribute;
 
 public class Account {
 	
@@ -130,7 +131,21 @@ public class Account {
 	public String getGender() {
 		return getPerson().getGender();
 	}
-	
+
+	public List<PersonAttribute> getActiveAttributes() {
+		return getPerson().getActiveAttributes();
+	}
+
+	public PersonAttribute getPersonAttribute(String attributeTypeUuid) {
+		Person person = getPerson();
+		if (person != null) {
+			PersonAttribute attr = person.getAttribute(Context.getPersonService().getPersonAttributeTypeByUuid(
+					attributeTypeUuid));
+			return attr;
+		}
+		return null;
+	}
+
 	public Role getPrivilegeLevel(User user) {
 		if (user != null && user.getRoles() != null) {
 			for (Role r : user.getRoles()) {

--- a/omod/src/main/webapp/fragments/systemadmin/accounts/personDetails.gsp
+++ b/omod/src/main/webapp/fragments/systemadmin/accounts/personDetails.gsp
@@ -10,6 +10,10 @@
 %>
 
 <% if(!createAccount) { %>
+<script type="text/javascript">
+    initPersonDetails(${customPersonAttributeJson});
+</script>
+
 <div id="adminui-person-details" ng-controller="EditPersonDetailsController"
      ng-init="init('${account.person.uuid}', '${account.gender}', '${account.person.personName.uuid}',
                    '${ui.encodeJavaScriptAttribute(account.familyName)}', '${ui.encodeJavaScriptAttribute(account.givenName)}', '${ui.message("Person.gender.male")}',
@@ -38,6 +42,19 @@
                     <th valign="top">${ui.message("Person.gender")}</th>
                     <td valign="top">{{genders[person.gender]}}</td>
                 </tr>
+
+                <% customPersonAttributeViewFragments.each { fragment ->
+                    if(fragment.extensionParams.type == 'personAttribute') { %>
+                    ${ ui.includeFragment(fragment.extensionParams.provider, fragment.extensionParams.fragment, [
+                            label : ui.message(fragment.extensionParams.label),
+                            personId : account.person.personId,
+                            personUuid : account.person.uuid,
+                            initialValue : ui.message(account.getPersonAttribute(fragment.extensionParams.uuid) != null ?
+                                    account.getPersonAttribute(fragment.extensionParams.uuid).value : '')
+                    ])}
+                    <% }
+                } %>
+
             </table>
         </div>
         <% } %>
@@ -97,6 +114,20 @@
                     ${ui.message("adminui.field.required")}
                 </span>
             </span>
+
+            <% customPersonAttributeEditFragments.each { fragment ->
+                if(fragment.extensionParams.type == 'personAttribute') {%>
+                ${ ui.includeFragment(fragment.extensionParams.provider, fragment.extensionParams.fragment, [
+                        formFieldName : fragment.extensionParams.formFieldName,
+                        id : fragment.extensionParams.formFieldName,
+                        title : ui.message(fragment.extensionParams.title),
+                        label : ui.message(fragment.extensionParams.label),
+                        initialValue : ui.message(account.getPersonAttribute(fragment.extensionParams.uuid) != null ?
+                                account.getPersonAttribute(fragment.extensionParams.uuid).value : '')
+                ])}
+            <% }
+            }%>
+
         </div>
         </fieldset>
 <% if(!createAccount) { %>

--- a/omod/src/main/webapp/fragments/systemadmin/accounts/userFormFields.gsp
+++ b/omod/src/main/webapp/fragments/systemadmin/accounts/userFormFields.gsp
@@ -128,6 +128,16 @@
        ng-model="uuidUserMap['${userUuid}'].userProperties.forcePassword" />${ ui.message("adminui.account.user.forcePasswordChange") }
 </p>
 
+<% customUserPropertyEditFragments.each { fragment -> %>
+    ${ ui.includeFragment(fragment.extensionParams.provider, fragment.extensionParams.fragment, [
+            formFieldName : fragment.extensionParams.userPropertyName + userUuid,
+            id : fragment.extensionParams.userPropertyName + userUuid,
+            title : ui.message(fragment.extensionParams.title),
+            label : ui.message(fragment.extensionParams.label),
+            initialValue : ''
+    ])}
+<% } %>
+
 <label>${ ui.message('adminui.account.capabilities') }</label>
 <table class="adminui-display-table" cellspacing="0" cellpadding="0">
     <%/* Group the them into 2 columns */%>

--- a/omod/src/main/webapp/fragments/systemadmin/accounts/userTabContentPane.gsp
+++ b/omod/src/main/webapp/fragments/systemadmin/accounts/userTabContentPane.gsp
@@ -3,6 +3,7 @@
 
     def user = config.user;
     def uuid = user.uuid ?: '';
+
 %>
 
 <div class="user-${uuid}" ${user.userId ? "" : "hidden"}>
@@ -30,6 +31,18 @@
                 {{yesOrNo[uuidUserMap['${uuid}'].userProperties.forcePassword]}}
             </td>
         </tr>
+
+        <% customUserPropertyViewFragments.each { fragment -> %>
+            ${ ui.includeFragment(fragment.extensionParams.provider, fragment.extensionParams.fragment, [
+                    label : ui.message(fragment.extensionParams.label),
+                    personId : account.person.personId,
+                    personUuid : account.person.uuid,
+                    userId : user.userId,
+                    userUuid : user.uuid
+            ])}
+        <% }
+        %>
+
         <tr>
             <th valign="top">${ui.message("adminui.account.capabilities")}</th>
             <td valign="top" ng-class="{retired: uuidUserMap['${uuid}'].retired}">

--- a/omod/src/main/webapp/resources/scripts/fragments/systemadmin/personDetails.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/systemadmin/personDetails.js
@@ -1,3 +1,10 @@
+
+var personAttributesMap;
+
+function initPersonDetails(personAttributes){
+    personAttributesMap = personAttributes;
+}
+
 angular.module("adminui.personDetails", ["personService"])
 
     .controller("EditPersonDetailsController", ["$scope", "Person",
@@ -13,6 +20,7 @@ angular.module("adminui.personDetails", ["personService"])
                 $scope.person.familyName = familyName;
                 $scope.person.givenName = givenName;
                 $scope.genders = {M: male, F: female};
+                $scope.personAttributesMap = personAttributesMap;
 
                 //cache the original state so that we can use it to reset later on cancel
                 $scope.originalState = angular.copy($scope.person);
@@ -45,13 +53,28 @@ angular.module("adminui.personDetails", ["personService"])
 
             $scope.save = function() {
                 $scope.beforeRequest();
+                attributesSet = []
+                angular.forEach($scope.personAttributesMap , function(value, key) {
+                    personAttributeUuid = value.personAttributeUuid;
+                    formFieldName = value.formFieldName;
+                    currentValue = document.getElementById(formFieldName).value;
+                    if (currentValue) {
+                        attributesSet.push({
+                            uuid : personAttributeUuid,
+                            value : currentValue
+                        })
+                    }
+                });
+
                 var personToSave = {
                     uuid: $scope.person.personUuid,
                     gender: $scope.person.gender,
                     names: [{
                         uuid: $scope.person.personNameUuid,
                         familyName: $scope.person.familyName,
-                        givenName: $scope.person.givenName}]
+                        givenName: $scope.person.givenName
+                    }],
+                    attributes: attributesSet
                 }
 
                 Person.save(personToSave).$promise.then(function () {

--- a/omod/src/main/webapp/resources/scripts/fragments/systemadmin/userDetails.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/systemadmin/userDetails.js
@@ -138,6 +138,15 @@ angular.module("adminui.userDetails", ["userService", "ngDialog", "adminui.shoul
                 if(modelUser.userProperties.forcePassword){
                     uProperties.forcePassword = "true";
                 }
+                angular.forEach(modelUser.userProperties, function(value, key) {
+                    if(key != "forcePassword") {
+                        var domElement = document.getElementById(key + userUuid);
+                        if (domElement) {
+                            uProperties[key] = domElement.value;
+                        }
+                    }
+                });
+                
                 var toSave = {
                     username: modelUser.username,
                     roles: privilegesLevelAndCapabilities,


### PR DESCRIPTION
# Description 

Along with this PR,
- Add New Account/Edit account dashboards can allow the fragments through the extensions
- It can allow the different fragments to Add/Edit Information and View information
- It can provide supports to save the person attributes (if the fragment field type is personAttribute) automatically along with the person registration/ person update.
- It can provide supports to save the user properties (if the fragment field type is userProperty) automatically along with the user registration/ user update.

# Ticket Information

Ticket : https://issues.openmrs.org/browse/RA-1513
