### PR TITLE
RA-1513 Minor Fix by adding person,user ids to the Manage account custom fragement support

### DIFF
--- a/omod/src/main/webapp/fragments/systemadmin/accounts/personDetails.gsp
+++ b/omod/src/main/webapp/fragments/systemadmin/accounts/personDetails.gsp
@@ -123,7 +123,9 @@
                         title : ui.message(fragment.extensionParams.title),
                         label : ui.message(fragment.extensionParams.label),
                         initialValue : ui.message(account.getPersonAttribute(fragment.extensionParams.uuid) != null ?
-                                account.getPersonAttribute(fragment.extensionParams.uuid).value : '')
+                                account.getPersonAttribute(fragment.extensionParams.uuid).value : ''),
+                        personId : account.person ? account.person.personId : "",
+                        personUuid : account.person ? account.person.uuid : ""
                 ])}
             <% }
             }%>

--- a/omod/src/main/webapp/fragments/systemadmin/accounts/userFormFields.gsp
+++ b/omod/src/main/webapp/fragments/systemadmin/accounts/userFormFields.gsp
@@ -134,7 +134,9 @@
             id : fragment.extensionParams.userPropertyName + userUuid,
             title : ui.message(fragment.extensionParams.title),
             label : ui.message(fragment.extensionParams.label),
-            initialValue : ''
+            initialValue : '',
+            userId : user ? user.userId : "" ,
+            userUuid : user ? user.uuid : ""
     ])}
 <% } %>
 


### PR DESCRIPTION
#Description 

Added some more information to the fragment configurations by,

- Add the personId, personUuid to the fragment configurations
- Add the userId, userUuid to the fragement configurations

Which can be accessed by the custom fragments easily.

# Ticket 

Ticket : https://issues.openmrs.org/browse/RA-1513