### PR TITLE
RA-930:Excluding Retired and Provider lists from the accounts list

### DIFF
--- a/api/src/main/java/org/openmrs/module/adminui/account/AccountService.java
+++ b/api/src/main/java/org/openmrs/module/adminui/account/AccountService.java
@@ -14,7 +14,7 @@ import java.util.List;
 import org.openmrs.Role;
 
 public interface AccountService {
-	
+
 	/**
 	 * Save the account details to the database
 	 *
@@ -22,22 +22,35 @@ public interface AccountService {
 	 * @should save the account
 	 */
 	void saveAccount(Account account);
-	
+
 	/**
 	 * @return
 	 * @should get all unique accounts
 	 */
 	List<Account> getAllAccounts();
-	
+
+	/**
+	 * @return
+	 * @should get all retired provider accounts
+	 */
+	List<Account> getAllRetiredProviderAccounts();
+
+	/**
+	 * @return
+	 * @should get all retired user accounts
+	 */
+	List<Account> getAllRetiredUserAccounts();
+
 	/**
 	 * Gets all Capabilities, i.e roles with the
-	 * {@link org.openmrs.module.adminui.AdminUiConstants#ROLE_PREFIX_CAPABILITY} prefix
+	 * {@link org.openmrs.module.adminui.AdminUiConstants#ROLE_PREFIX_CAPABILITY}
+	 * prefix
 	 *
 	 * @return a list of Roles
 	 * @should return all roles with the capability prefix
 	 */
 	List<Role> getAllCapabilities();
-	
+
 	/**
 	 * Gets all Privilege Levels, i.e roles with the
 	 *
@@ -45,5 +58,5 @@ public interface AccountService {
 	 * @should return all roles with the privilege level prefix
 	 */
 	List<Role> getAllPrivilegeLevels();
-	
+
 }

--- a/omod/src/main/java/org/openmrs/module/adminui/page/controller/systemadmin/accounts/ManageAccountsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/adminui/page/controller/systemadmin/accounts/ManageAccountsPageController.java
@@ -28,8 +28,9 @@ public class ManageAccountsPageController {
 	 */
 	public void get(PageModel model, @SpringBean("adminAccountService") AccountService accountService,
 	                @SpringBean("adminService") AdministrationService adminService) {
-		
+		List<Account> retiredUserAccounts = accountService.getAllRetiredUserAccounts();
 		List<Account> accounts = accountService.getAllAccounts();
+		accounts.removeAll(retiredUserAccounts);
 		model.addAttribute("accounts", accounts);
 		Map<Provider, String> providerNameMap = new HashMap<Provider, String>();
 		for (Account a : accountService.getAllAccounts()) {
@@ -44,6 +45,7 @@ public class ManageAccountsPageController {
 					
 					providerNameMap.put(p, (String) rows.get(0).get(0));
 				}
+
 			}
 		}
 		


### PR DESCRIPTION
for this issue, https://issues.openmrs.org/browse/RA-930  .I added two methods that is getAllRetiredUserAccounts() and getAllRetiredProviderAccounts()  which when excluded from getAccounts list,the list returned should not have the rtired user accounts or the provider accounts.