### PR TITLE
RA-1875: EMPT132 Fixed RootUI Error Vulnerability in Add Location

### DIFF
--- a/omod/src/main/java/org/openmrs/module/adminui/page/controller/metadata/locations/LocationPageController.java
+++ b/omod/src/main/java/org/openmrs/module/adminui/page/controller/metadata/locations/LocationPageController.java
@@ -176,7 +176,7 @@ public class LocationPageController {
     private String replaceArguments(String message, Object[] arguments) {
         if (arguments != null) {
             for (int i = 0; i < arguments.length; i++) {
-                String argument = (String) arguments[i];
+                String argument = String.valueOf(arguments[i]);
                 message = message.replaceAll("\\{" + i + "\\}", argument);
             }
         }


### PR DESCRIPTION
### Description of What I Changed

I changed the method to convert Object arguments to String.

### Issue I Worked On

The issue was that the 'Postal Code' field, present in the form for adding a new location, was having Integer Object value so it could not be converted to String using the existing casting method which was --> (String)arg[i]
I remedied this by using String.valueOf() function.

Steps to reproduce this vulnerability:

1. Launch the OpenMRS application.
2. Login with username "Admin" and password "Admin123" with location as Inpatient Ward.
3. Navigate to Configure Metadata from the main menu.
4. Click on 'Manage Locations' under Locations section.
5. Click on the 'Add New Location' button.
6. Fill dummy details as following: 'qwerty' as Name and 'qwerty' as Postal Code.
7. Click on 'Save'.

Output: RootUI error will be displayed.

### Link to ticket
[https://issues.openmrs.org/browse/RA-1875](https://issues.openmrs.org/browse/RA-1875)

@isears