### PR TITLE
RA-1875: EMPT133 patch for locationAttributeType

### DIFF
--- a/omod/src/main/webapp/pages/metadata/locations/locationAttributeType.gsp
+++ b/omod/src/main/webapp/pages/metadata/locations/locationAttributeType.gsp
@@ -43,6 +43,7 @@
                 },
                 "minOccurs": {
                     required: true
+                    maxlength: 9
                 },
                 "datatypeClassname": {
                     required: true,
@@ -120,7 +121,7 @@
                     label        : ui.message("adminui.minOccurs")+"<span class='adminui-text-red'>*</span>",
                     formFieldName: "minOccurs",
                     id           : "minOccurs",
-                    maxLength    : 101,
+                    maxLength    : 9,
                     initialValue : (locationAttributeType.minOccurs ?: '0')
                 ])}
                 </td>
@@ -129,7 +130,7 @@
                     label        : ui.message("adminui.maxOccurs"),
                     formFieldName: "maxOccurs",
                     id           : "maxOccurs",
-                    maxLength    : 101,
+                    maxLength    : 9,
                     initialValue : (locationAttributeType.maxOccurs ?: '')
                 ])}
                 </td>


### PR DESCRIPTION
# Description of what I changed
I changed the max length for the input for max and min occurs to 9.

# Issue I worked on
When a number that was bigger than the max size an int can be, it would cause a number exception. To fix this I made it so a number can only be 9 characters long for the min occurs and max occurs.

# It can be reproduced following

-Launch OpenMRS application using the URL: http://localhost:8080/openmrs
-Provide following info and click login​Username​ as ​admin​ Password​ ​ as ​admin123 Location as ​Inpatient
-Click on the “Configure Metadata” module.
-Click on “Manage Location Attribute Types”.
-Click on “Add New Location Attribute Type” button.
-Enter Test as Name and enter 10000000000000000 as Min Occurs and choose Provider Datatype as Datatype.
-Hit Save

# Link to ticket
https://issues.openmrs.org/browse/RA-1875

@isears 